### PR TITLE
タブレット・PC用ヘッダメニューのレイアウト修正

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -148,6 +148,10 @@ nav.open ul {
   overflow: scroll;
 }
 
+header nav li {
+  font-weight: 500;
+}
+
 header nav a {
   display: block;
   color: #ffffff;

--- a/css/tablet.css
+++ b/css/tablet.css
@@ -28,7 +28,17 @@ footer li {
 @media only screen and (min-width: 768px) {
 header h1 {
   display: table-cell;
-  padding: 10px 12px;
+  padding: 12px 12px;
+}
+
+header h1 .title {
+  height: 36px;
+  position: relative;
+  top: -2px;
+}
+
+header h1 .title:hover {
+  opacity: 0.7;
 }
 
 header nav {
@@ -39,6 +49,8 @@ header nav {
 }
 
 header nav ul {
+  padding-right: 16px;
+  font-size: 0;
   display: block;
 }
 
@@ -50,23 +62,27 @@ header nav li:nth-child(-n+3) {
   border-right: solid #a3a3a3 2px;
 }
 
+header nav li:nth-last-child(-n+2) a {
+  padding: 10px 4px;
+}
+
 header nav a {
   display: inline;
   color: #353535;
   font-size: 0.8rem;
-  padding: 10px 5px;
+  padding: 10px 12px;
   line-height: 0.8rem;
 }
 
 header nav a.twitter {
   background: url("../images/twitter-gray.png") no-repeat;
-  background-size: contain;
+  background-size: 70%;
   background-position: center;
 }
 
 header nav a.facebook {
   background: url("../images/facebook-gray.png") no-repeat;
-  background-size: contain;
+  background-size: 70%;
   background-position: center;
 }
 


### PR DESCRIPTION
#65 
@ehnh 下記確認願います
・ヘッダメニューのそれぞれの文字が右に寄るバグを修正しました
・ヘッダの幅(高さ)を増加させました
・Cyderロゴを大きくしました
・Cyderロゴを2pxだけ上にあげました (中央寄せでしたが、画像の特性上、目の錯覚で下がって見えていました)
・snsアイコンを小さくしました
・メニュー項目とsnsアイコンの間の余白を大きくしました
・メニュー項目間の余白を大きくしました
