### PR TITLE
Delete unavailable links which referred old sync-pod lp site

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -136,7 +136,7 @@
               <p>
                 <span>新しい動画視聴のカタチ。</span><span>離れた人と一緒に動画を楽しもう。</span>
               </p>
-              <a target="_blank" href="http://app.sync-pod.com">READ MORE</a>
+              <a target="_blank" href="http://syncpod.cyder.jp">READ MORE</a>
             </div>
           </article>
         </div>

--- a/public/news/syncpod20180502.html
+++ b/public/news/syncpod20180502.html
@@ -65,9 +65,7 @@
         <div class="text">
           <p>離れた人と一緒にYouTubeを閲覧できるスマホアプリ「SyncPod」のiOS版及びAndroid版をリリースしました。</p>
           <ul class="links">
-            <li><a target="_blank" href="http://app.sync-pod.com/">SyncPod 公式ページ</a></li>
-            <li><a target="_blank" href="https://itunes.apple.com/jp/app/syncpod/id1347783355">iOS版 SyncPod</a></li>
-            <li><a target="_blank" href="https://play.google.com/store/apps/details?id=com.cyder.android.syncpod">Android版 SyncPod</a></li>
+            <li><a target="_blank" href="http://syncpod.cyder.jp">SyncPod 公式ページ</a></li>
           </ul>
         </div>
       </article>

--- a/public/products/index.html
+++ b/public/products/index.html
@@ -78,7 +78,7 @@
           <p>
             <span>新しい動画視聴のカタチ。</span><span>離れた人と一緒に動画を楽しもう。</span>
           </p>
-          <a target="_blank" href="http://app.sync-pod.com">READ MORE</a>
+          <a target="_blank" href="http://syncpod.cyder.jp">READ MORE</a>
         </div>
       </article>
       <article class="aktiva">


### PR DESCRIPTION
```
% grep -r sync-pod.com ./*                                                                                                                                                                          (git)-[goodbye-syncpod-link]
./public/index.html:              <a target="_blank" href="http://app.sync-pod.com">READ MORE</a>
./public/products/index.html:          <a target="_blank" href="http://app.sync-pod.com">READ MORE</a>
./public/news/syncpod20180502.html:            <li><a target="_blank" href="http://app.sync-pod.com/">SyncPod 公式ページ</a></li>
```